### PR TITLE
Add support for Jekyll 4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
 .sass-cache
+.jekyll-cache
 .jekyll-metadata
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ end
 gem 'html-proofer'
 gem 'tzinfo'
 gem 'tzinfo-data'
+gem 'kramdown-parser-gfm'

--- a/textlog.gemspec
+++ b/textlog.gemspec
@@ -12,9 +12,8 @@ Gem::Specification.new do |spec|
 
 	spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|(LICENSE|README)((\.(txt|md|markdown)|$)))!i) }
 
-	spec.add_runtime_dependency "jekyll", "~> 3.5"
+	spec.add_runtime_dependency "jekyll", [">= 3.5", "< 5.0"]
 
 	spec.add_development_dependency "bundler", "~> 1.15"
 	spec.add_development_dependency "rake", "~> 12.0"
 end
-


### PR DESCRIPTION
Fixes #10

I tried building with this patch set using both Jekyll 3.x and 4.x and the result looks the same:

![Screen Shot 2021-10-08 at 19 08 48](https://user-images.githubusercontent.com/175286/136596841-4c82ea41-9831-42f7-9ff7-6d9997e94b9b.png)

As a part of [#hacktoberfest](https://github.com/topics/hacktoberfest) :)